### PR TITLE
Create crystal reef social hub with custom icons

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,9 +5,12 @@ export default function Footer(){
         <div className="flex flex-wrap gap-6 items-center justify-between">
           <div>© {new Date().getFullYear()} GoVanGoes / Cloutlandish LLC</div>
           <nav className="flex gap-4 flex-wrap">
-            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://tiktok.com/@govangoes">TikTok</a>
-            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://instagram.com/govangoes">Instagram</a>
-            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://youtube.com/@govangoes">YouTube</a>
+            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://www.instagram.com/govangoes/">Instagram</a>
+            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://x.com/GoVanGoes">X / Twitter</a>
+            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://www.tiktok.com/@govangoes">TikTok</a>
+            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://www.youtube.com/@govangoes">YouTube</a>
+            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://www.linkedin.com/in/evanmichaelfigueroa/">LinkedIn</a>
+            <a className="hover:text-ink dark:hover:text-paperWhite" href="https://www.reddit.com/user/GoVanGoes/">Reddit</a>
             <a className="hover:text-ink dark:hover:text-paperWhite" href="/press">Press</a>
             <a className="hover:text-ink dark:hover:text-paperWhite" href="/privacy">Privacy</a>
             <a className="hover:text-ink dark:hover:text-paperWhite" href="/terms">Terms</a>

--- a/src/components/SocialLinks.css
+++ b/src/components/SocialLinks.css
@@ -1,0 +1,257 @@
+.social-reef {
+  position: relative;
+  padding: clamp(2.5rem, 6vw, 4rem);
+  border-radius: 2.5rem;
+  overflow: hidden;
+  color: var(--core-paperWhite, #f5f7fb);
+  background:
+    radial-gradient(120% 120% at 10% -10%, rgba(34, 211, 238, 0.35), transparent 60%),
+    radial-gradient(120% 120% at 90% 0%, rgba(238, 62, 150, 0.24), transparent 65%),
+    linear-gradient(160deg, rgba(10, 16, 34, 0.94) 0%, rgba(19, 27, 52, 0.92) 45%, rgba(32, 41, 75, 0.88) 100%);
+  border: 1px solid rgba(34, 211, 238, 0.25);
+  box-shadow: 0 40px 110px rgba(4, 12, 30, 0.55), inset 0 0 60px rgba(34, 211, 238, 0.08);
+}
+
+.social-reef::before,
+.social-reef::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.social-reef::before {
+  background: radial-gradient(70% 60% at 50% 0%, rgba(255, 255, 255, 0.22), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+.social-reef::after {
+  background: url("data:image/svg+xml,%3Csvg width='600' height='320' viewBox='0 0 600 320' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 180c70 20 140 20 210 0s140-20 210 0 140 20 210 0v140H0Z' fill='rgba(34,211,238,0.12)'/%3E%3C/svg%3E");
+  background-repeat: repeat-x;
+  background-size: 120% auto;
+  transform: translateY(-35%);
+  opacity: 0.4;
+  animation: reef-wave 18s linear infinite;
+}
+
+.social-reef__aurora,
+.social-reef__caustics {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.social-reef__aurora {
+  background: radial-gradient(40% 40% at 20% 20%, rgba(255, 209, 102, 0.25), transparent 65%),
+              radial-gradient(55% 50% at 80% 30%, rgba(34, 211, 238, 0.18), transparent 80%);
+  mix-blend-mode: screen;
+  opacity: 0.75;
+}
+
+.social-reef__caustics {
+  background:
+    radial-gradient(140% 70% at 50% 120%, rgba(34, 211, 238, 0.18), transparent 70%),
+    radial-gradient(80% 50% at 70% 85%, rgba(111, 45, 168, 0.18), transparent 75%);
+  mix-blend-mode: overlay;
+  opacity: 0.55;
+  filter: blur(0.5px);
+}
+
+.social-reef__inner {
+  position: relative;
+  z-index: 1;
+}
+
+.social-reef__header {
+  max-width: 48rem;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.social-reef__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(34, 211, 238, 0.15);
+  border: 1px solid rgba(34, 211, 238, 0.35);
+  color: rgba(229, 244, 255, 0.85);
+}
+
+.social-reef__title {
+  margin-top: 1rem;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 700;
+}
+
+.social-reef__copy {
+  margin-top: 0.9rem;
+  font-size: 1rem;
+  color: rgba(229, 235, 255, 0.75);
+}
+
+.social-reef__grid {
+  margin-top: clamp(2rem, 5vw, 3rem);
+  display: grid;
+  gap: clamp(1.2rem, 3vw, 1.8rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.social-reef__item {
+  position: relative;
+  list-style: none;
+}
+
+.social-reef__link {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 1.1rem;
+  padding: 1.25rem 1.4rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(140deg, rgba(9, 20, 44, 0.8), rgba(34, 51, 85, 0.82));
+  border: 1px solid rgba(34, 211, 238, 0.18);
+  box-shadow: inset 0 0 40px rgba(34, 211, 238, 0.05);
+  transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+  text-decoration: none;
+  color: inherit;
+  backdrop-filter: blur(6px);
+}
+
+.social-reef__link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid transparent;
+  background: linear-gradient(140deg, rgba(34, 211, 238, 0.5), rgba(238, 62, 150, 0.3)) border-box;
+  mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.social-reef__link:hover,
+.social-reef__link:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(34, 211, 238, 0.45);
+  box-shadow: 0 16px 45px rgba(34, 211, 238, 0.16), inset 0 0 60px rgba(34, 211, 238, 0.08);
+}
+
+.social-reef__link:hover::after,
+.social-reef__link:focus-visible::after {
+  opacity: 0.8;
+}
+
+.social-reef__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.3rem;
+  height: 3.3rem;
+  border-radius: 1.2rem;
+  background: radial-gradient(110% 110% at 30% 20%, rgba(34, 211, 238, 0.25), transparent 70%);
+  box-shadow: inset 0 0 30px rgba(34, 211, 238, 0.15);
+  animation: float 5.5s ease-in-out infinite;
+}
+
+.social-reef__icon svg {
+  width: 2.6rem;
+  height: 2.6rem;
+}
+
+.social-reef__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.social-reef__name {
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.social-reef__handle {
+  font-size: 0.95rem;
+  color: rgba(208, 224, 255, 0.8);
+}
+
+.social-reef__tagline {
+  font-size: 0.85rem;
+  color: rgba(183, 204, 255, 0.7);
+}
+
+.social-reef__bubble {
+  position: absolute;
+  width: clamp(1.8rem, 4vw, 2.6rem);
+  height: clamp(1.8rem, 4vw, 2.6rem);
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.45), rgba(34, 211, 238, 0.15) 55%, rgba(34, 211, 238, 0));
+  top: 10%;
+  right: clamp(0.5rem, 2vw, 1rem);
+  filter: blur(0.2px);
+  opacity: 0.65;
+  animation: bubble-rise 8s ease-in-out infinite;
+  animation-delay: var(--delay, 0s);
+}
+
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes reef-wave {
+  0% {
+    transform: translateY(-35%) translateX(0);
+  }
+  100% {
+    transform: translateY(-35%) translateX(-50%);
+  }
+}
+
+@keyframes bubble-rise {
+  0% {
+    transform: translateY(0) scale(0.9);
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.55;
+  }
+  50% {
+    transform: translateY(-12px) scale(1);
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateY(-26px) scale(0.95);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .social-reef {
+    border-radius: 1.8rem;
+  }
+
+  .social-reef__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .social-reef__icon {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  .social-reef__icon svg {
+    width: 2.3rem;
+    height: 2.3rem;
+  }
+}

--- a/src/components/SocialLinks.jsx
+++ b/src/components/SocialLinks.jsx
@@ -2,32 +2,105 @@ import TikTokIcon from "../icons/TikTokIcon";
 import InstagramIcon from "../icons/InstagramIcon";
 import YouTubeIcon from "../icons/YouTubeIcon";
 import XIcon from "../icons/XIcon";
-import SpotifyIcon from "../icons/SpotifyIcon";
-import BeRealIcon from "../icons/BeRealIcon";
+import LinkedInIcon from "../icons/LinkedInIcon";
+import RedditIcon from "../icons/RedditIcon";
+
+import "./SocialLinks.css";
 
 const socials = [
-  { name: "TikTok",   href: "https://tiktok.com/@govangoes", Icon: TikTokIcon },
-  { name: "Instagram",href: "https://instagram.com/govangoes", Icon: InstagramIcon },
-  { name: "YouTube",  href: "https://youtube.com/@govangoes", Icon: YouTubeIcon },
-  { name: "X",        href: "https://twitter.com/govangoes", Icon: XIcon },
-  { name: "Spotify",  href: "#", Icon: SpotifyIcon },
-  { name: "BeReal",   href: "https://bere.al/govangoes", Icon: BeRealIcon },
+  {
+    name: "Instagram",
+    handle: "@govangoes",
+    href: "https://www.instagram.com/govangoes/",
+    tagline: "Snapshots from the crystal current.",
+    Icon: InstagramIcon,
+  },
+  {
+    name: "X / Twitter",
+    handle: "@GoVanGoes",
+    href: "https://x.com/GoVanGoes",
+    tagline: "Quick pulses from the squid signal.",
+    Icon: XIcon,
+  },
+  {
+    name: "TikTok",
+    handle: "@govangoes",
+    href: "https://www.tiktok.com/@govangoes",
+    tagline: "Short-form tides and crystal riffs.",
+    Icon: TikTokIcon,
+  },
+  {
+    name: "YouTube",
+    handle: "@GoVanGoes",
+    href: "https://www.youtube.com/@govangoes",
+    tagline: "Full dives, live sessions, deep lore.",
+    Icon: YouTubeIcon,
+  },
+  {
+    name: "LinkedIn",
+    handle: "Evan Michael Figueroa",
+    href: "https://www.linkedin.com/in/evanmichaelfigueroa/",
+    tagline: "Strategy, partnerships, and professional currents.",
+    Icon: LinkedInIcon,
+  },
+  {
+    name: "Reddit",
+    handle: "u/GoVanGoes",
+    href: "https://www.reddit.com/user/GoVanGoes/",
+    tagline: "Behind-the-scenes lore with the reef.",
+    Icon: RedditIcon,
+  },
 ];
 
-export default function SocialLinks({size=28, className=""}){
+export default function SocialLinks({ className = "" }) {
   return (
-    <nav aria-label="Social links" className={className}>
-      <ul className="flex flex-wrap items-center gap-4">
-        {socials.map(({name, href, Icon}) => (
-          <li key={name}>
-            <a href={href} target="_blank" rel="noopener noreferrer"
-               className="inline-flex items-center justify-center p-2 rounded-full bg-white/5 border border-white/10 hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-cyan-300/40">
-              <Icon size={size} className="social-crystal" />
-              <span className="sr-only">{name}</span>
-            </a>
-          </li>
-        ))}
-      </ul>
-    </nav>
+    <section
+      className={`social-reef ${className}`}
+      aria-labelledby="social-reef-title"
+      aria-describedby="social-reef-lede"
+    >
+      <div className="social-reef__aurora" aria-hidden="true" />
+      <div className="social-reef__caustics" aria-hidden="true" />
+      <div className="social-reef__inner">
+        <header className="social-reef__header">
+          <p className="social-reef__eyebrow" id="social-reef-lede">
+            Follow the Calamari Crystal current
+          </p>
+          <h2 className="social-reef__title" id="social-reef-title">
+            Connect across every reef signal
+          </h2>
+          <p className="social-reef__copy">
+            Each platform is a different tide — from fast-moving pulses to deep dives. Choose your
+            channel and ride the glow.
+          </p>
+        </header>
+        <ul className="social-reef__grid">
+          {socials.map(({ name, handle, href, tagline, Icon }, index) => (
+            <li key={name} className="social-reef__item">
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="social-reef__link"
+              >
+                <span className="social-reef__icon">
+                  <Icon size={48} className="social-crystal" />
+                </span>
+                <span className="social-reef__meta">
+                  <span className="social-reef__name">{name}</span>
+                  <span className="social-reef__handle">{handle}</span>
+                  <span className="social-reef__tagline">{tagline}</span>
+                </span>
+              </a>
+              <span
+                aria-hidden="true"
+                className="social-reef__bubble"
+                style={{ "--delay": `${index * 0.14}s` }}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
   );
 }

--- a/src/icons/InstagramIcon.jsx
+++ b/src/icons/InstagramIcon.jsx
@@ -1,10 +1,18 @@
 import SocialIconBase from "./SocialIconBase";
-export default function InstagramIcon(props){
+
+export default function InstagramIcon(props) {
   return (
     <SocialIconBase title="Instagram" {...props}>
-      <rect x="6" y="6" width="16" height="16" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="1.6"/>
-      <circle cx="14" cy="14" r="4.2" />
-      <circle cx="19.4" cy="8.6" r="1.4" />
+      <path
+        d="M8.2 9.1C8.2 7.4 9.6 6 11.3 6h5.4c1.7 0 3.1 1.4 3.1 3.1v5.4c0 1.7-1.4 3.1-3.1 3.1h-1.6"
+        strokeWidth="1.4"
+      />
+      <path
+        d="M9.2 18.6c1.3 1.9 4.1 2.5 6 1.2 1.9-1.2 2.4-3.6 1.1-5.4-1.1-1.4-3.1-1.8-4.7-.9"
+        strokeWidth="1.4"
+      />
+      <circle cx="19.1" cy="8.4" r="1.1" fill="currentColor" opacity="0.9" />
+      <path d="M8.2 11.4v4.5" strokeWidth="1.4" />
     </SocialIconBase>
   );
 }

--- a/src/icons/LinkedInIcon.jsx
+++ b/src/icons/LinkedInIcon.jsx
@@ -1,0 +1,13 @@
+import SocialIconBase from "./SocialIconBase";
+
+export default function LinkedInIcon(props) {
+  return (
+    <SocialIconBase title="LinkedIn" {...props}>
+      <circle cx="9.4" cy="8.4" r="1.2" fill="currentColor" />
+      <path d="M8.6 11.4v9.4" strokeWidth="1.4" />
+      <path d="M12.6 11.4v9.4" strokeWidth="1.4" />
+      <path d="M12.6 14.4c.5-1.6 1.9-2.6 3.4-2.6 2 0 3.6 1.6 3.6 3.6v5.4" strokeWidth="1.4" />
+      <path d="M19.6 10.4c-1.5-1.4-3.6-2.2-5.7-2.1" opacity="0.7" />
+    </SocialIconBase>
+  );
+}

--- a/src/icons/RedditIcon.jsx
+++ b/src/icons/RedditIcon.jsx
@@ -1,0 +1,16 @@
+import SocialIconBase from "./SocialIconBase";
+
+export default function RedditIcon(props) {
+  return (
+    <SocialIconBase title="Reddit" {...props}>
+      <path d="M14 6.6c1.5 0 2.9.4 4.1 1.2" opacity="0.7" />
+      <path d="M9 12.6c-1.7 1.1-2.7 2.6-2.7 4.3 0 3.1 3.2 5.6 7.7 5.6s7.7-2.5 7.7-5.6c0-1.7-1-3.3-2.7-4.3" strokeWidth="1.4" />
+      <circle cx="9" cy="11.4" r="1.3" fill="currentColor" />
+      <circle cx="19" cy="11.4" r="1.3" fill="currentColor" />
+      <circle cx="12.2" cy="15.4" r=".8" fill="currentColor" />
+      <circle cx="16" cy="15.4" r=".8" fill="currentColor" />
+      <path d="M12.5 19.4c.9.5 2.1.5 3 0" strokeWidth="1.3" />
+      <path d="M14 9.8l1-4.4 3.2 1" strokeWidth="1.3" />
+    </SocialIconBase>
+  );
+}

--- a/src/icons/SocialIconBase.jsx
+++ b/src/icons/SocialIconBase.jsx
@@ -1,4 +1,4 @@
-export default function SocialIconBase({ title, children, size=28, className="" }) {
+export default function SocialIconBase({ title, children, size = 28, className = "" }) {
   const id = Math.random().toString(36).slice(2);
   const labelled = Boolean(title);
   return (
@@ -7,23 +7,47 @@ export default function SocialIconBase({ title, children, size=28, className="" 
       height={size}
       viewBox="0 0 28 28"
       className={className}
-      {...(labelled ? { role: 'img', 'aria-label': title } : { 'aria-hidden': true, focusable: 'false' })}
+      {...(labelled
+        ? { role: "img", "aria-label": title }
+        : { "aria-hidden": true, focusable: "false" })}
     >
       <defs>
         <linearGradient id={`crystal-${id}`} x1="0" x2="1" y1="0" y2="1">
-          <stop offset="0%"  stopColor="var(--crystalCyan, #22d3ee)" />
-          <stop offset="100%" stopColor="var(--crystalViolet, #a78bfa)" />
+          <stop offset="0%" stopColor="var(--cc-crystalCyan, #22d3ee)" />
+          <stop offset="45%" stopColor="var(--accent-coralPink, #ff7c8a)" />
+          <stop offset="100%" stopColor="var(--cc-squidViolet, #6f2da8)" />
         </linearGradient>
-        <filter id={`glow-${id}`} x="-50%" y="-50%" width="200%" height="200%">
-          <feGaussianBlur stdDeviation="2.5" result="blur"/>
-          <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+        <radialGradient id={`bubble-${id}`} cx="0.2" cy="0.15" r="0.9">
+          <stop offset="0%" stopColor="rgba(255,255,255,0.85)" />
+          <stop offset="35%" stopColor="rgba(255,255,255,0.25)" />
+          <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+        </radialGradient>
+        <filter id={`glow-${id}`} x="-120%" y="-120%" width="340%" height="340%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="2.8" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
         </filter>
       </defs>
       <g filter={`url(#glow-${id})`}>
-        <path d="M14 1 L25 8 L25 20 L14 27 L3 20 L3 8 Z" fill="url(#crystal-${id})" opacity="0.12" />
-        <path d="M14 1 L25 8 L25 20 L14 27 L3 20 L3 8 Z" fill="none" stroke="url(#crystal-${id})" strokeWidth="1.3" />
+        <path
+          d="M14 1 L25.5 7.6 C26.4 8.1 26.4 9.4 25.5 9.9 L25.5 18.1 C25.5 18.7 25.2 19.2 24.7 19.5 L14 27 L3.3 19.5 C2.8 19.2 2.5 18.7 2.5 18.1 L2.5 9.9 C1.6 9.4 1.6 8.1 2.5 7.6 L14 1 Z"
+          fill="url(#crystal-${id})"
+          opacity="0.16"
+        />
+        <path
+          d="M14 1 L25.5 7.6 C26.4 8.1 26.4 9.4 25.5 9.9 L25.5 18.1 C25.5 18.7 25.2 19.2 24.7 19.5 L14 27 L3.3 19.5 C2.8 19.2 2.5 18.7 2.5 18.1 L2.5 9.9 C1.6 9.4 1.6 8.1 2.5 7.6 L14 1 Z"
+          fill="none"
+          stroke="url(#crystal-${id})"
+          strokeWidth="1.35"
+        />
+        <circle cx="8" cy="7" r="3" fill={`url(#bubble-${id})`} opacity="0.55" />
+        <circle cx="20" cy="21" r="2.4" fill={`url(#bubble-${id})`} opacity="0.35" />
       </g>
-      <g fill="url(#crystal-${id})" stroke="none">{children}</g>
+      <g fill="none" stroke="url(#crystal-${id})" strokeLinecap="round" strokeLinejoin="round">
+        {children}
+      </g>
     </svg>
   );
 }

--- a/src/icons/TikTokIcon.jsx
+++ b/src/icons/TikTokIcon.jsx
@@ -1,8 +1,18 @@
 import SocialIconBase from "./SocialIconBase";
-export default function TikTokIcon(props){
+
+export default function TikTokIcon(props) {
   return (
     <SocialIconBase title="TikTok" {...props}>
-      <path d="M18 6v2.2c1.6 1.4 3.1 2 5 2v3.1c-2.3 0-4.1-.7-5-1.4V17a5 5 0 1 1-3.8-4.86V9.5h3.8Z"/>
+      <path
+        d="M11 10.2c0-1.8 1.5-3.2 3.3-3.2h1.4c0 2.8 2.3 4.8 4.8 4.8"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M10 18.4c-.3-2.1 1.1-4 3.1-4.4 1.8-.4 3.5.6 3.9 2.3.6 2.6-1.8 4.9-4.6 4"
+        strokeWidth="1.5"
+      />
+      <path d="M11 12.9v6.3" strokeWidth="1.4" />
+      <circle cx="18.9" cy="8" r="1.4" fill="currentColor" opacity="0.75" />
     </SocialIconBase>
   );
 }

--- a/src/icons/XIcon.jsx
+++ b/src/icons/XIcon.jsx
@@ -1,9 +1,12 @@
 import SocialIconBase from "./SocialIconBase";
-export default function XIcon(props){
+
+export default function XIcon(props) {
   return (
     <SocialIconBase title="X" {...props}>
-      <path d="M8 8 L20 20" stroke="currentColor" strokeWidth="2"/>
-      <path d="M20 8 L8 20" stroke="currentColor" strokeWidth="2"/>
+      <path d="M7.8 8.4 12 12.6" strokeWidth="1.6" />
+      <path d="M16.2 16.8 20.4 21" strokeWidth="1.6" />
+      <path d="M20.4 8.4 7.6 21.2" strokeWidth="1.6" />
+      <path d="M16.6 7c-.9-.9-2.1-1.4-3.4-1.4-1.5 0-2.9.7-3.7 1.9" opacity="0.75" />
     </SocialIconBase>
   );
 }

--- a/src/icons/YouTubeIcon.jsx
+++ b/src/icons/YouTubeIcon.jsx
@@ -1,9 +1,14 @@
 import SocialIconBase from "./SocialIconBase";
-export default function YouTubeIcon(props){
+
+export default function YouTubeIcon(props) {
   return (
     <SocialIconBase title="YouTube" {...props}>
-      <rect x="5" y="9" width="18" height="10" rx="3" />
-      <polygon points="13,12 18,14 13,16"/>
+      <path
+        d="M7 11.2c.4-1.7 1.9-2.9 3.6-2.9h6.8c1.7 0 3.2 1.2 3.6 2.9.6 2.5.6 4.2 0 6.7-.4 1.7-1.9 2.9-3.6 2.9h-6.8c-1.7 0-3.2-1.2-3.6-2.9-.6-2.5-.6-4.2 0-6.7Z"
+        strokeWidth="1.4"
+      />
+      <path d="M12.2 12.6c0-.6.6-.9 1.1-.6l4 2.4a.7.7 0 0 1 0 1.2l-4 2.4c-.5.3-1.1 0-1.1-.6v-4.8Z" fill="currentColor" />
+      <path d="M8.8 8.4c1.1-1.4 2.7-2.3 4.5-2.4" opacity="0.7" />
     </SocialIconBase>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import Hero from "../components/Hero.jsx";
 import JellyButton from "../components/JellyButton.jsx";
+import SocialLinks from "../components/SocialLinks.jsx";
 import { Link } from "react-router-dom";
 
 const Card = ({ title, body, to }) => (
@@ -14,12 +15,16 @@ export default function Home(){
   return (
     <main className="bg-ink">
       <Hero />
-      
+
+      <div className="relative mx-auto max-w-6xl px-4 -mt-16 md:-mt-24">
+        <SocialLinks />
+      </div>
+
       {/* Add the JellyButton component here */}
       <section className="mx-auto max-w-6xl px-4 py-8 flex justify-center">
         <JellyButton onClick={() => alert('Hello from the Jelly Button!')}>Try the Jelly Button!</JellyButton>
       </section>
-      
+
       <section className="mx-auto max-w-6xl px-4 py-12 grid gap-6 md:grid-cols-3">
         <Card title="Lore: The Squid's Revenge"
               body="Betrayal → Escape → Crystal → Reckoning → Redemption. Dive into the chapters."


### PR DESCRIPTION
## Summary
- build a "Social Reef" section with an underwater-inspired UI tied to the Calamari Crystal palette and updated platform messaging
- refresh all social icons with custom crystal outlines and add new LinkedIn and Reddit glyphs for the latest profiles
- surface the new section on the home page and align footer links with the updated social destinations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e51e1b1aa08333a59f7618d5339f11