### PR TITLE
feat: ship launch accessibility fixes

### DIFF
--- a/POST-LAUNCH.md
+++ b/POST-LAUNCH.md
@@ -1,0 +1,6 @@
+# Post-launch backlog
+
+- [ ] Connect the contact form to the production CRM/Formspree endpoint and add an inline success state.
+- [ ] Expand Privacy and Terms pages with finalized legal copy and compliance review.
+- [ ] Design a compact mobile navigation pattern (drawer or menu button) for screens <640px.
+- [ ] Add additional press photography alt text/context once new assets are delivered.

--- a/api/dict.js
+++ b/api/dict.js
@@ -11,7 +11,7 @@ function loadDict() {
     const file = path.join(process.cwd(), "src", "data", "dictionary.json");
     const raw = fs.readFileSync(file, "utf8");
     return JSON.parse(raw);
-  } catch (e) {
+  } catch {
     return null;
   }
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://www.govangoes.com/</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
-  <url><loc>https://www.govangoes.com/story</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://www.govangoes.com/music</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://www.govangoes.com/merch</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://www.govangoes.com/marketing</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://www.govangoes.com/business</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://www.govangoes.com/bookings</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://www.govangoes.com/about</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://www.govangoes.com/press</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://www.govangoes.com/privacy</loc><lastmod>2025-10-13</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-  <url><loc>https://www.govangoes.com/terms</loc><lastmod>2025-10-13</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
-  <url><loc>https://www.govangoes.com/contact</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://www.govangoes.com/epk</loc><lastmod>2025-10-13</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://www.govangoes.com/</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
+  <url><loc>https://www.govangoes.com/story</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://www.govangoes.com/music</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://www.govangoes.com/merch</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://www.govangoes.com/marketing</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://www.govangoes.com/business</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://www.govangoes.com/bookings</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://www.govangoes.com/about</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://www.govangoes.com/press</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://www.govangoes.com/privacy</loc><lastmod>2025-10-23</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.govangoes.com/terms</loc><lastmod>2025-10-23</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://www.govangoes.com/contact</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://www.govangoes.com/epk</loc><lastmod>2025-10-23</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,9 @@ export default function App() {
       <RouteSEO />
       <BackgroundPattern />
       <div className="relative z-10 min-h-screen text-ink dark:text-paperWhite">
+        <a className="skip-link" href="#main">
+          Skip to content
+        </a>
         <CursorSquid />
         <NavBar />
         <Routes>

--- a/src/components/EPKGallery.css
+++ b/src/components/EPKGallery.css
@@ -1,4 +1,9 @@
 .epk-card {
+  display: block;
+  width: 100%;
+  padding: 0;
+  font: inherit;
+  color: inherit;
   position: relative;
   cursor: pointer;
   perspective: 1200px;

--- a/src/components/EPKGallery.jsx
+++ b/src/components/EPKGallery.jsx
@@ -44,19 +44,13 @@ export default function EPKGallery({ items: itemsProp }) {
         {items.map((it, idx) => {
           // Prefer WebP now that variants are generated at build-time.
           return (
-            <figure
+            <button
               key={(it.src || "") + idx}
-              className="epk-card focus:outline-none"
-              role="button"
-              tabIndex={0}
+              type="button"
+              className="epk-card focus:outline-none text-left"
               onClick={() => setOpenIndex(idx)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  setOpenIndex(idx);
-                }
-              }}
               aria-label={`View ${it.title || "press photo"}`}
+              aria-haspopup="dialog"
             >
               <div className="epk-card__inner">
                 <div className="epk-card__face epk-card__face--front">
@@ -93,20 +87,29 @@ export default function EPKGallery({ items: itemsProp }) {
                       )
                     )}
                     {it.captionLink && it.captionLink.href && (
-                      <a
-                        href={it.captionLink.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                      <span
+                        role="link"
+                        tabIndex={0}
                         className="epk-card__link"
-                        onClick={(event) => event.stopPropagation()}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          window.open(it.captionLink.href, "_blank", "noopener,noreferrer");
+                        }}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            window.open(it.captionLink.href, "_blank", "noopener,noreferrer");
+                          }
+                        }}
                       >
                         {it.captionLink.label || "Learn more"}
-                      </a>
+                      </span>
                     )}
                   </div>
                 </div>
               </div>
-            </figure>
+            </button>
           );
         })}
       </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,6 +5,9 @@ export default function Footer() {
         <div className="flex flex-wrap gap-6 items-center justify-between">
           <div>© {new Date().getFullYear()} GoVanGoes / Cloutlandish LLC</div>
           <nav className="flex gap-4 flex-wrap">
+            <a className="hover:text-ink dark:hover:text-paperWhite" href="mailto:hello@govangoes.com">
+              hello@govangoes.com
+            </a>
             <a
               className="hover:text-ink dark:hover:text-paperWhite"
               href="https://tiktok.com/@govangoes"

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -48,7 +48,6 @@ export default function Lightbox({ items = [], index = 0, onClose, onPrev, onNex
   const title = it?.title || "";
   const caption = it?.caption || "";
   const alt = it?.alt || title || "Press photo";
-  const webp = toWebp(src);
 
   return (
     <div

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -6,7 +6,7 @@ const LinkItem = ({ to, children }) => (
   <NavLink
     to={to}
     className={({ isActive }) =>
-      `px-3 py-2 rounded-md text-sm font-medium transition
+      `px-4 py-3 leading-6 rounded-md text-sm font-medium transition
        ${
          isActive
            ? "text-crystal dark:bg-graphite/60 bg-ink/10 ring-1 ring-crystal/40 shadow-crystal"
@@ -21,14 +21,14 @@ const LinkItem = ({ to, children }) => (
 export default function NavBar() {
   return (
     <header className="sticky top-0 z-50 backdrop-blur-md bg-paperWhite/70 dark:bg-ink/50 border-b border-ink/10 dark:border-paperWhite/10">
-      <nav className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+      <nav className="mx-auto max-w-6xl px-4 py-3 flex flex-wrap items-center justify-between gap-y-3">
         <div className="flex items-center gap-2">
           <Gem className="h-5 w-5 text-monteGold" />
           <span className="font-semibold tracking-wide text-ink dark:text-paperWhite">
             GoVanGoes
           </span>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2">
           <LinkItem to="/">Home</LinkItem>
           <LinkItem to="/story">Lore</LinkItem>
           <LinkItem to="/music">

--- a/src/components/Parallax.jsx
+++ b/src/components/Parallax.jsx
@@ -24,7 +24,7 @@ export default function Parallax({ amount = 24, className = "", children }) {
       el.style.transform = `translate3d(0, ${y.toFixed(2)}px, 0)`;
     }
     function onScroll() {
-      if (!raf) raf = requestAnimationFrame(update);
+      if (!raf) raf = window.requestAnimationFrame(update);
     }
     el.style.willChange = "transform";
     onScroll();
@@ -33,7 +33,7 @@ export default function Parallax({ amount = 24, className = "", children }) {
     return () => {
       window.removeEventListener("scroll", onScroll);
       window.removeEventListener("resize", onScroll);
-      if (raf) cancelAnimationFrame(raf);
+      if (raf) window.cancelAnimationFrame(raf);
     };
   }, [amount]);
 

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -30,7 +30,7 @@ export default function ThemeToggle() {
       type="button"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
       aria-pressed={theme === "dark"}
-      className="ml-2 p-2 rounded-md border border-white/10 bg-white/5 hover:bg-white/10 transition"
+      className="ml-2 flex h-11 w-11 items-center justify-center rounded-md border border-white/10 bg-white/5 hover:bg-white/10 transition"
       title={theme === "dark" ? "Switch to light" : "Switch to dark"}
     >
       {theme === "dark" ? (

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,30 @@
   body {
     @apply antialiased;
   }
+
+  :focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 3px;
+  }
+
+  .skip-link {
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, -150%);
+    padding: 0.5rem 1.25rem;
+    border-radius: 0.75rem;
+    background-color: #ffd700;
+    color: #0b0a12;
+    font-weight: 600;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+    transition: transform 150ms ease, box-shadow 150ms ease;
+    z-index: 50;
+  }
+
+  .skip-link:focus-visible {
+    transform: translate(-50%, 0.75rem);
+    box-shadow: 0 14px 35px rgba(0, 0, 0, 0.25);
+  }
 }
 
 /* === Small helpers you can reuse in components === */

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -14,7 +14,7 @@ export default function About() {
     });
   }, []);
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16">
       <h1 className="text-3xl font-bold">About</h1>
       <p className="mt-3 text-paperWhite/80">
         Wildly Influential. Unapologetically Different. The GoVanGoes story and mission.

--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -14,7 +14,7 @@ export default function Bookings() {
     });
   }, []);
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16">
       <h1 className="text-3xl font-bold">Bookings</h1>
       <p className="mt-3 text-paperWhite/80">For shows, brand events, press, and collaborations.</p>
       <p className="mt-6">Email: hello@govangoes.com</p>

--- a/src/pages/Business.jsx
+++ b/src/pages/Business.jsx
@@ -7,7 +7,7 @@ export default function Business() {
     ["Licensing/Digital", "$5k target"],
   ];
   return (
-    <section className="space-y-8">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16 space-y-8">
       <header className="text-center">
         <h1 className="text-3xl md:text-4xl font-extrabold">Cloutlandish LLC • Year 1 Focus</h1>
         <p className="opacity-80 mt-2">Power • Play • Precision</p>
@@ -25,6 +25,6 @@ export default function Business() {
           Booking & Collabs
         </a>
       </div>
-    </section>
+    </main>
   );
 }

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,39 +1,109 @@
+const formEndpoint = import.meta.env.VITE_CONTACT_FORM_ENDPOINT;
+
 export default function Contact() {
   return (
-    <section className="max-w-2xl mx-auto space-y-6">
-      <header className="text-center">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-2xl px-4 py-16 space-y-8">
+      <header className="text-center space-y-2">
         <h1 className="text-3xl font-extrabold">Contact / Bookings</h1>
-        <p className="opacity-80 mt-2">Shows, brand events, press, collabs.</p>
+        <p className="opacity-80">Shows, brand events, press, collabs.</p>
+        <p className="text-sm opacity-70">
+          Prefer direct email? Reach us at{' '}
+          <a className="underline" href="mailto:bookings@govangoes.com">
+            bookings@govangoes.com
+          </a>
+          .
+        </p>
       </header>
-      <form className="space-y-4" action="https://formspree.io/f/your-id-here" method="POST">
-        <input
-          className="w-full p-3 rounded bg-ink/50 border border-white/10"
-          name="name"
-          placeholder="Your name"
-          required
-        />
-        <input
-          className="w-full p-3 rounded bg-ink/50 border border-white/10"
-          name="email"
-          type="email"
-          placeholder="Email"
-          required
-        />
-        <input
-          className="w-full p-3 rounded bg-ink/50 border border-white/10"
-          name="subject"
-          placeholder="Subject"
-        />
-        <textarea
-          className="w-full p-3 rounded bg-ink/50 border border-white/10 h-32"
-          name="message"
-          placeholder="Tell us about the gig/collab"
-        />
-        <button className="px-5 py-3 rounded bg-ultraviolet text-paperWhite hover:opacity-90">
-          Send
+      <form
+        className="space-y-5"
+        action={formEndpoint || undefined}
+        method="POST"
+        onSubmit={(event) => {
+          if (formEndpoint) return;
+          event.preventDefault();
+          const formData = new window.FormData(event.currentTarget);
+          const subject = `Booking inquiry from ${formData.get("name") || "GoVanGoes fan"}`;
+          const details = [
+            `Email: ${formData.get("email") || "(not provided)"}`,
+            formData.get("subject") ? `Subject: ${formData.get("subject")}` : null,
+            "",
+            formData.get("message") || "",
+          ]
+            .filter(Boolean)
+            .join("\n");
+          const mailto = `mailto:bookings@govangoes.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(details)}`;
+          window.location.href = mailto;
+        }}
+      >
+        <div className="flex flex-col gap-2">
+          <label className="font-semibold" htmlFor="contact-name">
+            Name
+          </label>
+          <input
+            id="contact-name"
+            className="w-full rounded-md border border-white/10 bg-ink/50 px-3 py-3"
+            name="name"
+            type="text"
+            autoComplete="name"
+            required
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="font-semibold" htmlFor="contact-email">
+            Email
+          </label>
+          <input
+            id="contact-email"
+            className="w-full rounded-md border border-white/10 bg-ink/50 px-3 py-3"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="font-semibold" htmlFor="contact-subject">
+            Subject
+          </label>
+          <input
+            id="contact-subject"
+            className="w-full rounded-md border border-white/10 bg-ink/50 px-3 py-3"
+            name="subject"
+            type="text"
+            autoComplete="organization-title"
+            placeholder="Tour stop, brand event, press, etc."
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="font-semibold" htmlFor="contact-message">
+            Message
+          </label>
+          <textarea
+            id="contact-message"
+            className="w-full rounded-md border border-white/10 bg-ink/50 px-3 py-3"
+            name="message"
+            rows="6"
+            placeholder="Tell us about the gig or collaboration"
+            required
+          />
+        </div>
+        <div className="sr-only" aria-hidden="true">
+          <label htmlFor="contact-company">Company</label>
+          <input id="contact-company" name="company" tabIndex="-1" autoComplete="off" />
+        </div>
+        <button
+          type="submit"
+          className="w-full rounded-full bg-ultraviolet px-6 py-3 text-center font-semibold text-paperWhite transition hover:opacity-90"
+        >
+          Send message
         </button>
+        {!formEndpoint && (
+          <p className="text-xs text-ink/60 dark:text-paperWhite/60">
+            Tip: Until the CRM is connected post-launch, the button opens your email client with the
+            details pre-filled.
+          </p>
+        )}
       </form>
-      <p className="opacity-60 text-sm text-center">Or email: hello@govangoes.com</p>
-    </section>
+    </main>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,4 @@
 import Hero from "../components/Hero.jsx";
-import JellyButton from "../components/JellyButton.jsx";
 import { Link } from "react-router-dom";
 import ScrollReveal from "../components/ScrollReveal.jsx";
 import { YouTubeEmbed, SpotifyEmbed } from "../components/Embeds.jsx";
@@ -18,7 +17,7 @@ const Card = ({ title, body, to }) => (
 
 export default function Home() {
   return (
-    <main className="bg-ink">
+    <main id="main" tabIndex="-1" className="bg-ink">
       <Hero />
 
       {/* In-page quick nav */}

--- a/src/pages/Marketing.jsx
+++ b/src/pages/Marketing.jsx
@@ -17,7 +17,7 @@ const timeline = [
 
 export default function Marketing() {
   return (
-    <section className="space-y-10">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16 space-y-10">
       <header className="text-center space-y-2">
         <h1 className="text-3xl md:text-4xl font-extrabold">Rollout Strategy</h1>
         <p className="opacity-80">Narrative-first content. High engagement, low overhead.</p>
@@ -42,6 +42,6 @@ export default function Marketing() {
           Book a strategy session →
         </a>
       </div>
-    </section>
+    </main>
   );
 }

--- a/src/pages/Merch.jsx
+++ b/src/pages/Merch.jsx
@@ -20,7 +20,7 @@ const items = [
 
 export default function Merch() {
   return (
-    <section className="space-y-8">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16 space-y-8">
       <header className="text-center">
         <h1 className="text-3xl md:text-4xl font-extrabold">Relics from the Deep</h1>
         <p className="opacity-80 mt-2">Limited runs. Story-driven. Built for super-fans.</p>
@@ -44,6 +44,6 @@ export default function Merch() {
           </ScrollReveal>
         ))}
       </div>
-    </section>
+    </main>
   );
 }

--- a/src/pages/Music.jsx
+++ b/src/pages/Music.jsx
@@ -14,7 +14,7 @@ export default function Music() {
     });
   }, []);
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16">
       <h1 className="text-3xl font-bold">Music</h1>
       <p className="mt-3 text-paperWhite/80">Latest singles, EPs, and concept‑album tracks.</p>
     </main>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,6 +1,6 @@
 export default function NotFound() {
   return (
-    <section className="min-h-[50vh] grid place-items-center text-center">
+    <main id="main" tabIndex="-1" className="min-h-[50vh] grid place-items-center px-4 text-center">
       <div>
         <h1 className="text-5xl font-extrabold">404</h1>
         <p className="opacity-80 mt-2">The current carried this page away.</p>
@@ -8,6 +8,6 @@ export default function NotFound() {
           Back to shore
         </a>
       </div>
-    </section>
+    </main>
   );
 }

--- a/src/pages/Press.jsx
+++ b/src/pages/Press.jsx
@@ -17,7 +17,7 @@ export default function Press() {
   }, []);
   return (
     <>
-      <main className="mx-auto max-w-6xl px-4 py-16">
+      <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16">
         <h1 className="text-3xl font-bold">{epkHero?.title || "Press Kit"}</h1>
         {epkHero?.tagline && (
           <p className="mt-2 text-sm uppercase tracking-wide text-crystal">{epkHero.tagline}</p>

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -14,7 +14,7 @@ export default function Privacy() {
     });
   }, []);
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16">
       <h1 className="text-3xl font-bold">Privacy Policy</h1>
       <p className="mt-3 text-paperWhite/80">
         We respect your privacy. This placeholder page will outline data usage and policies.

--- a/src/pages/Story.jsx
+++ b/src/pages/Story.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Story() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16 space-y-8">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16 space-y-8">
       <header>
         <h1 className="text-4xl font-bold">The Calamari Crystal Chronicle</h1>
         <p className="mt-2 text-paperWhite/75">

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -14,7 +14,7 @@ export default function Terms() {
     });
   }, []);
   return (
-    <main className="mx-auto max-w-6xl px-4 py-16">
+    <main id="main" tabIndex="-1" className="mx-auto max-w-6xl px-4 py-16">
       <h1 className="text-3xl font-bold">Terms of Service</h1>
       <p className="mt-3 text-paperWhite/80">
         General terms for using this site and purchasing products. Placeholder copy.


### PR DESCRIPTION
## Summary
- add a skip link, focus styles, and larger tap targets across the navigation
- standardize page `<main>` landmarks and relabel the contact form with a mailto fallback
- improve EPK gallery semantics, surface the footer contact email, and capture post-launch follow-ups

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa47bbd8a48333bcc19231efae097c