### PR TITLE
fix: remove hero image glow

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -36,7 +36,7 @@ export default function Hero() {
               <img
                 src={`/${fallbackSources[0]}.png`}
                 alt={altText}
-                className="w-full drop-shadow-2xl shadow-crystal mx-auto"
+                className="w-full mx-auto"
                 loading="eager"
                 fetchPriority="high"
                 decoding="async"


### PR DESCRIPTION
## Summary
- remove the custom drop shadow classes from the hero image so it no longer renders a glow box

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690118c76d108333b33b6af3f7ce6eef