### PR TITLE
perf: salvage route lazy-loading from #50

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,28 +1,29 @@
 import { Routes, Route, useLocation } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import TopNav from "./components/TopNav.jsx";
 import Footer from "./components/Footer.jsx";
 import CrystalDock from "./components/ui/CrystalDock.jsx";
 import Home from "./pages/Home.jsx";
-import Story from "./pages/Story.jsx";
-import Merch from "./pages/Merch.jsx";
-import Marketing from "./pages/Marketing.jsx";
-import Business from "./pages/Business.jsx";
-import Contact from "./pages/Contact.jsx";
-import Press from "./pages/Press.jsx";
-import Music from "./pages/Music.jsx";
-import RapMap from "./pages/RapMap.jsx";
-import LyricsLab from "./pages/LyricsLab.jsx";
-import Artists from "./pages/Artists.jsx";
-import ArtistProfile from "./pages/ArtistProfile.jsx";
-import Upload from "./pages/Upload.jsx";
-import OpenMicsOrlando from "./pages/OpenMicsOrlando.jsx";
-import Bookings from "./pages/Bookings.jsx";
-import About from "./pages/About.jsx";
-import Privacy from "./pages/Privacy.jsx";
-import Terms from "./pages/Terms.jsx";
-import Services from "./pages/Services.jsx";
-import NotFound from "./pages/NotFound.jsx";
+
+const Services = lazy(() => import("./pages/Services.jsx"));
+const Story = lazy(() => import("./pages/Story.jsx"));
+const Merch = lazy(() => import("./pages/Merch.jsx"));
+const Marketing = lazy(() => import("./pages/Marketing.jsx"));
+const Business = lazy(() => import("./pages/Business.jsx"));
+const Contact = lazy(() => import("./pages/Contact.jsx"));
+const Press = lazy(() => import("./pages/Press.jsx"));
+const Music = lazy(() => import("./pages/Music.jsx"));
+const RapMap = lazy(() => import("./pages/RapMap.jsx"));
+const Artists = lazy(() => import("./pages/Artists.jsx"));
+const ArtistProfile = lazy(() => import("./pages/ArtistProfile.jsx"));
+const LyricsLab = lazy(() => import("./pages/LyricsLab.jsx"));
+const Upload = lazy(() => import("./pages/Upload.jsx"));
+const OpenMicsOrlando = lazy(() => import("./pages/OpenMicsOrlando.jsx"));
+const Bookings = lazy(() => import("./pages/Bookings.jsx"));
+const About = lazy(() => import("./pages/About.jsx"));
+const Privacy = lazy(() => import("./pages/Privacy.jsx"));
+const Terms = lazy(() => import("./pages/Terms.jsx"));
+const NotFound = lazy(() => import("./pages/NotFound.jsx"));
 
 function ScrollToTop() {
   const { pathname } = useLocation();
@@ -30,6 +31,14 @@ function ScrollToTop() {
     window.scrollTo(0, 0);
   }, [pathname]);
   return null;
+}
+
+function RouteLoading() {
+  return (
+    <div className="flex min-h-[40vh] items-center justify-center text-sm text-paperWhite/70">
+      Loading...
+    </div>
+  );
 }
 
 export default function App() {
@@ -43,28 +52,30 @@ export default function App() {
       <div className="min-h-dvh bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-slate-900 via-[#0a0a0a] to-black text-paperWhite flex flex-col">
         <TopNav onMenuStateChange={setIsMenuOverlayActive} />
         <div className="flex-1">
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/services" element={<Services />} />
-            <Route path="/story" element={<Story />} />
-            <Route path="/merch" element={<Merch />} />
-            <Route path="/marketing" element={<Marketing />} />
-            <Route path="/business" element={<Business />} />
-            <Route path="/contact" element={<Contact />} />
-            <Route path="/press" element={<Press />} />
-            <Route path="/music" element={<Music />} />
-            <Route path="/rap-map" element={<RapMap />} />
-            <Route path="/artists" element={<Artists />} />
-            <Route path="/artists/:id" element={<ArtistProfile />} />
-            <Route path="/lyrics-lab" element={<LyricsLab />} />
-            <Route path="/upload" element={<Upload />} />
-            <Route path="/open-mics" element={<OpenMicsOrlando />} />
-            <Route path="/bookings" element={<Bookings />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/privacy" element={<Privacy />} />
-            <Route path="/terms" element={<Terms />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <Suspense fallback={<RouteLoading />}>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/services" element={<Services />} />
+              <Route path="/story" element={<Story />} />
+              <Route path="/merch" element={<Merch />} />
+              <Route path="/marketing" element={<Marketing />} />
+              <Route path="/business" element={<Business />} />
+              <Route path="/contact" element={<Contact />} />
+              <Route path="/press" element={<Press />} />
+              <Route path="/music" element={<Music />} />
+              <Route path="/rap-map" element={<RapMap />} />
+              <Route path="/artists" element={<Artists />} />
+              <Route path="/artists/:id" element={<ArtistProfile />} />
+              <Route path="/lyrics-lab" element={<LyricsLab />} />
+              <Route path="/upload" element={<Upload />} />
+              <Route path="/open-mics" element={<OpenMicsOrlando />} />
+              <Route path="/bookings" element={<Bookings />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/privacy" element={<Privacy />} />
+              <Route path="/terms" element={<Terms />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
         </div>
         <Footer />
         {showCrystalDock && <CrystalDock menuOpen={isMenuOverlayActive} />}


### PR DESCRIPTION
## Summary
- salvage route-level lazy-loading from #50
- keep `/` eagerly loaded and lazy-load secondary routes
- add a lightweight suspense fallback for route chunk loading

Supersedes #50