### PR TITLE
Fix website audit findings

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,6 @@
         } catch (e) {}
       })();
     </script>
-    <!-- Preload critical hero image for faster LCP -->
-    <link rel="preload" as="image" href="/squid_emblem.png" fetchpriority="high" />
     <link rel="canonical" href="https://www.govangoes.com/" />
 
     <script type="application/ld+json">
@@ -25,13 +23,13 @@
         "@type": "MusicGroup",
         "name": "GoVanGoes",
         "url": "https://www.govangoes.com/",
-        "image": "https://www.govangoes.com/og.jpg",
+        "image": "https://www.govangoes.com/icon-192.png",
         "genre": "Hip-Hop",
         "foundingLocation": "Florida, USA",
         "sameAs": [
-          "https://tiktok.com/@govangoes",
-          "https://instagram.com/govangoes",
-          "https://youtube.com/@govangoes",
+          "https://www.tiktok.com/@govangoes",
+          "https://www.instagram.com/govangoes",
+          "https://www.youtube.com/@govangoes",
           "https://twitter.com/govangoes"
         ]
       }
@@ -57,14 +55,14 @@
           "@type": "MusicGroup",
           "name": "GoVanGoes"
         },
-        "image": "https://govangoes.com/og.jpg",
+        "image": "https://www.govangoes.com/icon-192.png",
         "genre": "Hip-Hop",
         "inLanguage": "en",
         "url": "https://www.govangoes.com/",
         "albumRelease": {
           "@type": "MusicRelease",
           "albumReleaseType": "AlbumRelease",
-          "url": "https://govangoes.com/"
+          "url": "https://www.govangoes.com/"
         }
       }
     </script>
@@ -86,26 +84,17 @@
       property="og:description"
       content="Bold performance hip-hop. Power, play, precision. Underdogs rise."
     />
-    <meta property="og:image" content="/og.jpg" />
-    <meta property="og:image:width" content="1280" />
-    <meta property="og:image:height" content="640" />
+    <meta property="og:image" content="https://www.govangoes.com/icon-192.png" />
+    <meta property="og:image:width" content="192" />
+    <meta property="og:image:height" content="192" />
+    <meta property="og:image:alt" content="GoVanGoes icon" />
 
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="GoVanGoes — Calamari Crystal" />
     <meta name="twitter:description" content="Bold performance hip-hop. Power, play, precision." />
-    <meta name="twitter:image" content="/og.jpg" />
+    <meta name="twitter:image" content="https://www.govangoes.com/icon-192.png" />
+    <meta name="twitter:image:alt" content="GoVanGoes icon" />
     <title>GoVanGoes • Calamari Crystal</title>
-    <meta
-      name="description"
-      content="A Monte Cristo revenge tale remixed undersea. The Calamari Crystal saga by GoVanGoes."
-    />
-    <link rel="icon" href="/squid_emblem.png" />
-    <meta property="og:title" content="GoVanGoes — Calamari Crystal" />
-    <meta property="og:description" content="Dive into the saga: betrayal, treasure, redemption." />
-    <meta property="og:image" content="/og.jpg" />
-    <meta name="theme-color" content="#020617" />
-
-    <!-- Analytics already added above with environment guard -->
 
     <!-- Fonts: Preload once /public/fonts contains WOFF2 files -->
     <!--
@@ -115,34 +104,12 @@
     <link rel="preload" as="font" type="font/woff2" href="/fonts/CalamariSans-Italic.woff2" crossorigin>
     -->
 
-    <!-- JSON-LD: Website + Organization -->
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "GoVanGoes",
-        "url": "https://www.govangoes.com/",
-        "potentialAction": {
-          "@type": "SearchAction",
-          "target": "https://govangoes.com/?q={search_term_string}",
-          "query-input": "required name=search_term_string"
-        }
-      }
-    </script>
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "MusicGroup",
-        "name": "GoVanGoes",
-        "url": "https://www.govangoes.com/",
-        "genre": "Hip-hop, EDM, Pop, Reggae",
-        "foundingLocation": "Florida, USA",
-        "sameAs": [
-          "https://www.instagram.com/govangoes",
-          "https://www.tiktok.com/@govangoes",
-          "https://www.youtube.com/@govangoes",
-          "https://twitter.com/govangoes"
-        ]
+        "url": "https://www.govangoes.com/"
       }
     </script>
   </head>

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/govangoes/calamari-crystal-site/issues"
   },
   "engines": {
-    "node": "20.x",
+    "node": ">=20.19.0 <21 || >=22.12.0",
     "npm": ">=9.0.0"
   },
   "type": "module",
   "scripts": {
-    "prebuild": "node scripts/update-sitemap-lastmod.mjs && node scripts/optimize-images.mjs",
+    "prebuild": "node scripts/optimize-images.mjs",
     "dev": "vite",
     "build": "vite build",
     "build:gh": "cross-env GITHUB_PAGES=true vite build",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -3,12 +3,11 @@
   "short_name": "GoVanGoes",
   "icons": [
     { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" },
     {
-      "src": "/maskable-icon-512.png",
+      "src": "/maskable-icon-512.webp",
       "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
+      "type": "image/webp",
+      "purpose": "any maskable"
     }
   ],
   "theme_color": "#0B0B12",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://www.govangoes.com/</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://www.govangoes.com/story</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://www.govangoes.com/music</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
@@ -7,7 +7,7 @@
   <url><loc>https://www.govangoes.com/artists</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.govangoes.com/upload</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.govangoes.com/lyrics-lab</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-  <url><loc>https://www.govangoes.com/open-mics-orlando</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://www.govangoes.com/open-mics</loc><lastmod>2026-06-05</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.govangoes.com/merch</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://www.govangoes.com/marketing</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
   <url><loc>https://www.govangoes.com/business</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
@@ -18,5 +18,4 @@
   <url><loc>https://www.govangoes.com/privacy</loc><lastmod>2026-02-15</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.govangoes.com/terms</loc><lastmod>2026-02-15</lastmod><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.govangoes.com/contact</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
-  <url><loc>https://www.govangoes.com/epk</loc><lastmod>2026-02-15</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
 </urlset>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,6 +62,7 @@ export default function App() {
               <Route path="/business" element={<Business />} />
               <Route path="/contact" element={<Contact />} />
               <Route path="/press" element={<Press />} />
+              <Route path="/epk" element={<Press />} />
               <Route path="/music" element={<Music />} />
               <Route path="/rap-map" element={<RapMap />} />
               <Route path="/artists" element={<Artists />} />
@@ -69,6 +70,7 @@ export default function App() {
               <Route path="/lyrics-lab" element={<LyricsLab />} />
               <Route path="/upload" element={<Upload />} />
               <Route path="/open-mics" element={<OpenMicsOrlando />} />
+              <Route path="/open-mics-orlando" element={<OpenMicsOrlando />} />
               <Route path="/bookings" element={<Bookings />} />
               <Route path="/about" element={<About />} />
               <Route path="/privacy" element={<Privacy />} />

--- a/src/components/forms/BookingForm.jsx
+++ b/src/components/forms/BookingForm.jsx
@@ -10,6 +10,9 @@ import { copyTextToClipboard, submitFormWithFallback } from "./formUtils.js";
 
 const EVENT_TYPES = ["Show", "Hosting", "Brand", "Other"];
 const BUDGET_RANGES = ["Under $500", "$500-$1,000", "$1,000-$2,500", "$2,500+"];
+const ENDPOINT_SUCCESS_MESSAGE = "Received. I’ll reply in 24–48 hours.";
+const MAILTO_FALLBACK_MESSAGE =
+  "Your email app is opening with the details. Send that email to finish the request.";
 
 const INITIAL_FIELDS = {
   name: "",
@@ -57,6 +60,7 @@ export default function BookingForm({ className = "" }) {
   const [validationMessage, setValidationMessage] = useState("");
   const [feedbackMessage, setFeedbackMessage] = useState("");
   const [successSummary, setSuccessSummary] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
   const subject = "Booking Inquiry — Go Van Goes";
 
   const formattedBody = useMemo(() => formatBookingBody(fields), [fields]);
@@ -98,11 +102,15 @@ export default function BookingForm({ className = "" }) {
       formattedBody,
     });
 
+    const submittedToEndpoint = result.via === "endpoint";
+    const nextMessage = submittedToEndpoint ? ENDPOINT_SUCCESS_MESSAGE : MAILTO_FALLBACK_MESSAGE;
+
     setSuccessSummary(copyPayload);
-    if (result.via === "endpoint") {
+    setSuccessMessage(nextMessage);
+    if (submittedToEndpoint) {
       setFields(INITIAL_FIELDS);
     }
-    setFeedbackMessage("Received. I’ll reply in 24–48 hours.");
+    setFeedbackMessage(nextMessage);
     setIsSubmitting(false);
   };
 
@@ -112,7 +120,7 @@ export default function BookingForm({ className = "" }) {
     <CrystalCard as="form" variant="glass" className={rootClassName} onSubmit={handleSubmit}>
       {successSummary && (
         <CrystalCard variant="outline" className="space-y-3 border-crystal/35 bg-crystal/10 p-4">
-          <p className="text-sm font-medium text-strong">Received. I’ll reply in 24–48 hours.</p>
+          <p className="text-sm font-medium text-strong">{successMessage}</p>
           <GhostButton as="button" type="button" onClick={() => copySummary(successSummary)}>
             Copy summary
           </GhostButton>

--- a/src/components/forms/MixMasterForm.jsx
+++ b/src/components/forms/MixMasterForm.jsx
@@ -12,6 +12,9 @@ const TIERS = [
   { name: "Pro", price: "$129", detail: "2 revisions • typical 1–2 days" },
   { name: "Deluxe", price: "$199", detail: "cleanup/tuning • typical 24–48 hours" },
 ];
+const ENDPOINT_SUCCESS_MESSAGE = "Received. I’ll reply in 24–48 hours.";
+const MAILTO_FALLBACK_MESSAGE =
+  "Your email app is opening with the details. Send that email to finish the request.";
 
 const INITIAL_FIELDS = {
   name: "",
@@ -67,6 +70,7 @@ export default function MixMasterForm({ className = "", fileUploadUrl = "" }) {
   const [validationMessage, setValidationMessage] = useState("");
   const [feedbackMessage, setFeedbackMessage] = useState("");
   const [successSummary, setSuccessSummary] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
   const subject = "Mix / Master Intake — Go Van Goes";
 
   const selectedTier = useMemo(
@@ -147,10 +151,14 @@ export default function MixMasterForm({ className = "", fileUploadUrl = "" }) {
       formattedBody: formatMixMasterBody(normalizedFields, selectedTier),
     });
 
+    const submittedToEndpoint = result.via === "endpoint";
+    const nextMessage = submittedToEndpoint ? ENDPOINT_SUCCESS_MESSAGE : MAILTO_FALLBACK_MESSAGE;
+
     setSuccessSummary(
       `Subject: ${subject}\n\n${formatMixMasterBody(normalizedFields, selectedTier)}`,
     );
-    if (result.via === "endpoint") {
+    setSuccessMessage(nextMessage);
+    if (submittedToEndpoint) {
       setFields(INITIAL_FIELDS);
     } else {
       setFields((previous) => ({
@@ -158,7 +166,7 @@ export default function MixMasterForm({ className = "", fileUploadUrl = "" }) {
         referenceLink: normalizedReferenceLink,
       }));
     }
-    setFeedbackMessage("Received. I’ll reply in 24–48 hours.");
+    setFeedbackMessage(nextMessage);
     setIsSubmitting(false);
   };
 
@@ -168,7 +176,7 @@ export default function MixMasterForm({ className = "", fileUploadUrl = "" }) {
     <CrystalCard as="form" variant="glass" className={rootClassName} onSubmit={handleSubmit}>
       {successSummary && (
         <CrystalCard variant="outline" className="space-y-3 border-crystal/35 bg-crystal/10 p-4">
-          <p className="text-sm font-medium text-strong">Received. I’ll reply in 24–48 hours.</p>
+          <p className="text-sm font-medium text-strong">{successMessage}</p>
           <GhostButton as="button" type="button" onClick={() => copySummary(successSummary)}>
             Copy summary
           </GhostButton>

--- a/src/content/links.js
+++ b/src/content/links.js
@@ -1,16 +1,31 @@
 import { HAS_SPOTIFY, HAS_YOUTUBE, SPOTIFY_ID, SPOTIFY_TYPE, YT_VIDEO_ID } from "./media.js";
 
 const clean = (value) => (value && value.trim() ? value.trim() : "");
+const PLACEHOLDER_URLS = new Set([
+  "https://your-artist.bandcamp.com",
+  "https://your-store-link",
+  "https://bandsintown.com/your-artist",
+  "https://formspree.io/f/your-id-here",
+]);
+
+function configuredUrl(value) {
+  const url = clean(value);
+  if (!url) return "";
+  const normalized = url.toLowerCase();
+  if (PLACEHOLDER_URLS.has(normalized)) return "";
+  if (normalized.includes("replace_with") || normalized.includes("your-id-here")) return "";
+  return url;
+}
 
 export const SPOTIFY_URL = HAS_SPOTIFY
   ? `https://open.spotify.com/${SPOTIFY_TYPE}/${SPOTIFY_ID}`
   : "";
 export const YOUTUBE_URL =
-  clean(import.meta.env.VITE_YT_CHANNEL_URL) ||
+  configuredUrl(import.meta.env.VITE_YT_CHANNEL_URL) ||
   (HAS_YOUTUBE ? `https://www.youtube.com/watch?v=${YT_VIDEO_ID}` : "");
 export const APPLE_MUSIC_URL = "https://music.apple.com/us/artist/go-van-goes/1462114556";
-export const BANDCAMP_URL = clean(import.meta.env.VITE_BANDCAMP_URL);
-export const AUDIO_PROOF_URL = clean(import.meta.env.VITE_AUDIO_PROOF_URL);
+export const BANDCAMP_URL = configuredUrl(import.meta.env.VITE_BANDCAMP_URL);
+export const AUDIO_PROOF_URL = configuredUrl(import.meta.env.VITE_AUDIO_PROOF_URL);
 
 export const PRESS_FEATURE_LINKS = [
   {
@@ -28,13 +43,12 @@ export const PRESS_FEATURE_LINKS = [
 ];
 
 export const FILE_UPLOAD_URL =
-  clean(import.meta.env.VITE_FILE_UPLOAD_URL) ||
+  configuredUrl(import.meta.env.VITE_FILE_UPLOAD_URL) ||
   "https://drive.google.com/drive/folders/1ZSxhU4_faGw33ARMDqDPIbo0aXhDxG5R?usp=sharing";
 
-export const SHOP_URL = clean(import.meta.env.VITE_SHOP_URL);
-export const TOUR_URL = clean(import.meta.env.VITE_TOUR_URL);
-export const NEWSLETTER_FORM_ACTION =
-  clean(import.meta.env.VITE_NEWSLETTER_FORM_ACTION) || "https://formspree.io/f/your-id-here";
+export const SHOP_URL = configuredUrl(import.meta.env.VITE_SHOP_URL);
+export const TOUR_URL = configuredUrl(import.meta.env.VITE_TOUR_URL);
+export const NEWSLETTER_FORM_ACTION = configuredUrl(import.meta.env.VITE_NEWSLETTER_FORM_ACTION);
 
 export const STREAMING_LINKS = [
   { label: "Spotify", href: SPOTIFY_URL },

--- a/src/content/shows.js
+++ b/src/content/shows.js
@@ -2,29 +2,12 @@ import { TOUR_URL } from "./links.js";
 
 const hasTourLink = Boolean(TOUR_URL);
 
-// Replace with real dates and ticket links.
-export const shows = [
-  {
-    date: "2026-03-14",
-    city: "Orlando, FL",
-    venue: "Will's Pub",
-    status: "Tickets",
-  },
-  {
-    date: "2026-04-02",
-    city: "Atlanta, GA",
-    venue: "The Masquerade",
-    status: "Tickets",
-  },
-  {
-    date: "2026-04-19",
-    city: "Philadelphia, PA",
-    venue: "The Foundry",
-    status: "VIP",
-  },
-].map((show) => ({
+// Add real upcoming dates and ticket links here.
+const upcomingShows = [];
+
+export const shows = upcomingShows.map((show) => ({
   ...show,
-  href: hasTourLink ? TOUR_URL : "",
+  href: show.href || (hasTourLink ? TOUR_URL : ""),
 }));
 
 export const showsCta = hasTourLink ? { label: "See all dates", href: TOUR_URL } : null;

--- a/src/pages/Bookings.jsx
+++ b/src/pages/Bookings.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { CONTACT_EMAIL } from "../content/offers.js";
 import setSEO from "../utils/seo.js";
 
 export default function Bookings() {
@@ -7,8 +8,8 @@ export default function Bookings() {
       title: "Bookings — GoVanGoes",
       description: "Shows, brand events, press, and collaborations.",
       url: "https://www.govangoes.com/bookings",
-      image: "/og-image.png",
-      imageAlt: "GoVanGoes crest",
+      image: "/icon-192.png",
+      imageAlt: "GoVanGoes icon",
       site: "@govangoes",
       author: "GoVanGoes",
     });
@@ -17,7 +18,9 @@ export default function Bookings() {
     <main className="mx-auto max-w-6xl px-4 py-16">
       <h1 className="text-3xl font-bold">Bookings</h1>
       <p className="mt-3 text-paperWhite/80">For shows, brand events, press, and collaborations.</p>
-      <p className="mt-6">Email: hello@govangoes.com</p>
+      <p className="mt-6">
+        Email: <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+      </p>
     </main>
   );
 }

--- a/src/utils/seo.js
+++ b/src/utils/seo.js
@@ -1,3 +1,11 @@
+const FALLBACK_SOCIAL_IMAGE = "/icon-192.png";
+const MISSING_SOCIAL_IMAGES = new Set(["/og.jpg", "/og-image.png"]);
+
+function resolveSocialImage(image) {
+  if (!image || MISSING_SOCIAL_IMAGES.has(image)) return FALLBACK_SOCIAL_IMAGE;
+  return image;
+}
+
 export function setSEO({ title, description, image, imageAlt, url, author, site } = {}) {
   const hasWindow = typeof window !== "undefined" && window.location;
   const origin = hasWindow ? window.location.origin : "";
@@ -35,16 +43,17 @@ export function setSEO({ title, description, image, imageAlt, url, author, site 
     set('meta[name="twitter:description"]', "content", description);
   }
 
-  const absImage = image
-    ? image.startsWith("http")
-      ? image
-      : origin + image
+  const resolvedImage = resolveSocialImage(image);
+  const absImage = resolvedImage.startsWith("http")
+    ? resolvedImage
     : origin
-      ? origin + "/og-image.png"
+      ? origin + resolvedImage
       : undefined;
   if (absImage) {
     set('meta[property="og:image"]', "content", absImage);
     set('meta[name="twitter:image"]', "content", absImage);
+    set('meta[property="og:image:width"]', "content", "192");
+    set('meta[property="og:image:height"]', "content", "192");
     if (imageAlt) {
       set('meta[property="og:image:alt"]', "content", imageAlt);
       set('meta[name="twitter:image:alt"]', "content", imageAlt);

--- a/vercel.json
+++ b/vercel.json
@@ -42,7 +42,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://plausible.io; frame-src https://www.youtube.com https://youtube.com https://open.spotify.com; font-src 'self' data:; base-uri 'self'; form-action 'self'; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://plausible.io https://formspree.io https://api.web3forms.com https://submit-form.com; frame-src https://www.youtube.com https://youtube.com https://open.spotify.com; font-src 'self' data:; base-uri 'self'; form-action 'self' https://formspree.io https://api.web3forms.com https://submit-form.com; object-src 'none'"
         },
         { "key": "Referrer-Policy", "value": "no-referrer-when-downgrade" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },


### PR DESCRIPTION
## Summary
- clean up homepage metadata, manifest icons, social image fallbacks, sitemap routes, and SPA aliases
- make booking/mix form fallback messaging accurate when submissions fall back to mailto
- centralize booking email usage, filter placeholder links, remove stale past show dates, and allow configured form endpoints in CSP
- stop mutating sitemap lastmod during prebuild and align the Node engine range with Vite 7

## Verification
- compared `codex/audit-fixes-20260605-current` against `main`: 12 files changed, 0 commits behind
- local build/lint/browser verification was not run because the local workspace shell/path was unavailable in this session